### PR TITLE
Found a small typo in the link to Google's copy of jquery.

### DIFF
--- a/projectname/templates/base.html
+++ b/projectname/templates/base.html
@@ -40,7 +40,7 @@
     
     {% if debug %}{% include 'includes/debug.html' %}{% endif %}
     {% block javascript_library %}
-    <script src="//http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
     <script>!window.jQuery && document.write(unescape('%3Cscript src="{{ STATIC_URL }}js/jquery-1.6.1.min.js"%3E%3C/script%3E'))</script>
     {% endblock %}
     {% block javascript %}{% endblock %}


### PR DESCRIPTION
Saw the error in the browser console and thought I'd point it out.

Also, a related minor nitpick: the static link to jquery in base.html reads "jquery-1.6.1.min.js" but the file itself is named jquery.1.6.1.min.js. 

Cheers!
